### PR TITLE
Java: upgrade sample to Java 21 (LTS)

### DIFF
--- a/Java.code-workspace
+++ b/Java.code-workspace
@@ -4,6 +4,12 @@
       "path": "."
     }
   ],
+  "settings": {
+    // This sample targets Java 21 (LTS). Configure a JDK 21 in VS Code (Java: Configure Java Runtime)
+    // or set JAVA_HOME to a JDK 21 path and restart VS Code.
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.debug.settings.forceBuildBeforeLaunch": true
+  },
   "launch": {
     "version": "0.2.0",
     "configurations": [

--- a/Java/.gitignore
+++ b/Java/.gitignore
@@ -54,4 +54,7 @@ hs_err_pid*
 /*.vscode/
 /target/
 
+# Java upgrade tool artifacts (generated locally)
+/.github/java-upgrade/
+
 *.iml

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <build>
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.14.1</version>
             </plugin>
         </plugins>
     </build>

--- a/Java/readme.md
+++ b/Java/readme.md
@@ -8,9 +8,20 @@
 
 To run this application, ensure you have the following installed:
 
-- **Java Development Kit (JDK)**: Version 8 or higher.
+- **Java Development Kit (JDK)**: Version 21 (LTS).
 - **Maven**: For managing dependencies.
 - **Azure Account**: You need an Azure subscription. If you don’t have one, you can [create a free account](https://azure.com/free).
+
+### VS Code setup (recommended)
+
+If you want to run/debug this sample from VS Code:
+
+1. Install the Java extension pack: `vscjava.vscode-java-pack`
+2. Ensure VS Code is using a JDK 21 runtime:
+    - Command Palette → **Java: Configure Java Runtime** → set a **JavaSE-21** runtime as default, OR
+    - Set `JAVA_HOME` to a JDK 21 path and restart VS Code.
+
+If Maven fails with `invalid target release: 21`, it usually means Maven is running under an older Java (for example Java 8). Make sure `JAVA_HOME` points to JDK 21 and that your terminal/VS Code session was restarted after setting it.
 
 ## Dependencies
 
@@ -21,17 +32,17 @@ The project uses Azure SDK libraries, which can be included in your Maven `pom.x
     <dependency>
         <groupId>com.azure.resourcemanager</groupId>
         <artifactId>azure-resourcemanager-resources</artifactId>
-        <version>2.41.0</version> <!-- Check for the latest version -->
+        <version>2.51.0</version>
     </dependency>
     <dependency>
         <groupId>com.azure.resourcemanager</groupId>
         <artifactId>azure-resourcemanager-cosmos</artifactId>
-        <version>2.41.0</version>
+        <version>2.51.0</version>
     </dependency>
     <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-identity</artifactId>
-        <version>1.12.2</version>
+        <version>1.15.2</version>
     </dependency>
     <dependency>
         <groupId>org.slf4j</groupId>
@@ -65,6 +76,10 @@ The project uses Azure SDK libraries, which can be included in your Maven `pom.x
    ```bash
    mvn exec:java -Dexec.mainClass="com.example.CosmosDBManagement"
    ```
+
+### Debug in VS Code
+
+- Open [Java.code-workspace](../Java.code-workspace) and use **Run and Debug** → **Java: Debug sample**.
 
 ## Functionality
 

--- a/Java/src/main/java/com/example/CosmosDBManagement.java
+++ b/Java/src/main/java/com/example/CosmosDBManagement.java
@@ -200,26 +200,26 @@ public class CosmosDBManagement {
         String scopeString;
         switch (scope) {
             case Subscription:
-                scopeString = String.format("/subscriptions/%s", subscriptionId);
+                scopeString = "/subscriptions/%s".formatted(subscriptionId);
                 break;
             case ResourceGroup:
-                scopeString = String.format("/subscriptions/%s/resourceGroups/%s", subscriptionId, resourceGroupName);
+                scopeString = "/subscriptions/%s/resourceGroups/%s".formatted(subscriptionId, resourceGroupName);
                 break;
             case Account:
-                scopeString = String.format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s",
-                        subscriptionId, resourceGroupName, accountName);
+                scopeString = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s".formatted(
+                    subscriptionId, resourceGroupName, accountName);
                 break;
             case Database:
-                scopeString = String.format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s/dbs/%s",
-                        subscriptionId, resourceGroupName, accountName, databaseName);
+                scopeString = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s/dbs/%s".formatted(
+                    subscriptionId, resourceGroupName, accountName, databaseName);
                 break;
             case Container:
-                scopeString = String.format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s/dbs/%s/colls/%s",
-                        subscriptionId, resourceGroupName, accountName, databaseName, containerName);
+                scopeString = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s/dbs/%s/colls/%s".formatted(
+                    subscriptionId, resourceGroupName, accountName, databaseName, containerName);
                 break;
             default:
-                scopeString = String.format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s",
-                        subscriptionId, resourceGroupName, accountName);
+                scopeString = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s".formatted(
+                    subscriptionId, resourceGroupName, accountName);
                 break;
         }
         return scopeString;


### PR DESCRIPTION
Upgrades the Java Cosmos DB management SDK sample to Java 21 (LTS).

Changes:
- Update Maven compiler target/source to 21
- Apply Java 21 compatibility edits in the sample code
- Update VS Code workspace settings and README to document Java 21 prerequisites
- Ignore local Java upgrade tool artifacts

Validation:
- mvn test (with JDK 21)